### PR TITLE
Fix custom field view

### DIFF
--- a/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
+++ b/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
@@ -38,9 +38,7 @@ module RedmineMultiColumnIssuesHelperPatch
           if value.custom_field.multi_column?
             s << "</tr></table>\n"
             s << "<hr />\n"
-            s << "<div class=\"wiki\">\n"
-            s << "<strong>#{ h(value.custom_field.name) }</strong><p>#{ simple_format_without_paragraph(h(show_value(value))) }</p>\n"
-            s << "</div>\n"
+            s << "\t<table><th style=\"vertical-align:top;text-align:left;width: 200px;\">#{ h(value.custom_field.name) }:</th><td>#{ simple_format_without_paragraph(h(show_value(value))) }</td></table>\n"
             s << "<table class=\"attributes\">"
             n = 0
           else


### PR DESCRIPTION
Fixes https://github.com/ande3577/redmine_multi_column_custom_fields/issues/9
The field title and value are now aligned instead of being one under the
other.
This is not the most elegant implementation (doesn't use CSS, assigns fixed width to the title) but it does the job. If somebody has a better way, please suggest it but I wanted to get this issue moving.
