### PR TITLE
content does not span all columns

### DIFF
--- a/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
+++ b/lib/redmine_multi_column_custom_fields/issues_helper_patch.rb
@@ -38,7 +38,7 @@ module RedmineMultiColumnIssuesHelperPatch
         ordered_values.compact.each do |value|
           if value.custom_field.multi_column?
             s << "</tr><tr>\n"
-            s << "<td colspan='0'><div class='wiki'>\n"
+            s << "<td colspan='4'><div class='wiki'>\n"
             s << "<hr />\n"
             s << "<p><strong>#{ h(value.custom_field.name) }</strong></p><br />\n"
             s << "<p>#{ simple_format_without_paragraph(h(show_value(value))) }</p>\n"


### PR DESCRIPTION
Using redmine 3.0.1 and chrome, the multi column fields reserve correctly the space from all the columns, however the actual cell content is still limited to 1 column, leaving blank space on the right. Setting colspan to 4 corrects this