### PR TITLE
fix layout for multicolumn checkboxes

### DIFF
--- a/assets/stylesheets/multi_column_custom_fields.css
+++ b/assets/stylesheets/multi_column_custom_fields.css
@@ -1,3 +1,3 @@
 div.multicolumnform { width: 100% }
 div.multicolumnform textarea { width: 99% }
-div.multicolumnform input { width: 99% }
+div.multicolumnform input:not([type=checkbox]) { width: 99% }


### PR DESCRIPTION
This change sets input element width to 99% only if they are not checkbox. In the case of checkboxes, there is a text next to the checkbox which is not correctly displayed if the checkbox is 99%