### PR TITLE
fix layout for multicolumn radio buttons

### DIFF
--- a/assets/stylesheets/multi_column_custom_fields.css
+++ b/assets/stylesheets/multi_column_custom_fields.css
@@ -1,3 +1,3 @@
 div.multicolumnform { width: 100% }
 div.multicolumnform textarea { width: 99% }
-div.multicolumnform input:not([type=checkbox]) { width: 99% }
+div.multicolumnform input:not([type=checkbox]):not([type=radio]) { width: 99% }


### PR DESCRIPTION
This change sets input element width to 99% only if they are not checkboxes nor radio button. In the case of checkboxes or radio buttons, there is a text next to the checkbox or radio button which is not correctly displayed if the checkbox or radio button is 99%